### PR TITLE
Replace of deprecate include module by import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,6 @@
   become: yes
   when: (ansible_os_family == 'RedHat' and ansible_distribution_major_version == "7")
 
-- include: python.yml
+- import_tasks: python.yml
 
-- include: install.yml
+- import_tasks: install.yml


### PR DESCRIPTION
Using this playbook gave me the following warning before: `"include" is deprecated, use include_tasks/import_tasks instead. See https://docs.ansible.com/ansible-core/2.14/user_guide/playbooks_reuse_includes.html for details. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting deprecation_warnings=False  in ansible.cfg.`